### PR TITLE
Improve mobile layout with hamburger menus

### DIFF
--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { SiEthereum } from 'react-icons/si';
 
 import { useAuth, useLogout } from '../api/auth';
 import { LoginButton } from './LoginButton';
+import { SidebarHamburger } from './layout/SidebarHamburger';
 
 export const Navbar: FC = () => {
     const data = useMatches();
@@ -29,6 +30,7 @@ export const Navbar: FC = () => {
         <>
             <div className="w-full bg-secondary fixed top-0 grid grid-cols-[1fr_auto_1fr] h-8 z-10">
                 <div className="flex items-stretch gap-2 h-full px-3">
+                    <SidebarHamburger />
                     <Link
                         to="/"
                         className="text-primary font-bold text-base hover:underline py-1 flex items-center gap-1"

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -8,12 +8,14 @@ import { ProseWidthSwitcher } from './preferences/ProseWidthSwitcher';
 import { ThemeSwitcher } from './preferences/ThemeSwitcher';
 import { WorkshopChatsNav } from './workshop/WorkshopChatsNav';
 
-export const Sidebar = () => {
+import classNames from 'classnames';
+
+export const Sidebar = ({ className = '' }: { className?: string } = {}) => {
     const { pathname } = useRouterState({ select: (s) => s.location });
     const { isAuthenticated } = useAuth();
 
     return (
-        <div className="left-bar space-y-2">
+        <div className={classNames('left-bar space-y-2', className)}>
             <div className="flex flex-col justify-between h-full">
                 <nav className="w-full space-y-1.5 p-4">
                     <div className="px-1.5">

--- a/web/src/components/layout/RightbarHamburger.tsx
+++ b/web/src/components/layout/RightbarHamburger.tsx
@@ -1,0 +1,25 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { FiMenu } from 'react-icons/fi';
+import { LuX } from 'react-icons/lu';
+import { ReactNode } from 'react';
+
+export const RightbarHamburger = ({ children }: { children: ReactNode }) => {
+    return (
+        <Dialog.Root>
+            <Dialog.Trigger asChild>
+                <button className="md:hidden button aspect-square size-8 flex items-center justify-center">
+                    <FiMenu />
+                </button>
+            </Dialog.Trigger>
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40 data-[state=open]:animate-overlayShow" />
+                <Dialog.Content className="fixed inset-y-0 right-0 w-64 max-w-full bg-primary p-4 overflow-y-auto z-50 data-[state=open]:animate-contentShow">
+                    {children}
+                    <Dialog.Close className="absolute top-2 right-2 rounded-md p-1 hover:bg-secondary">
+                        <LuX className="size-5" />
+                    </Dialog.Close>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+};

--- a/web/src/components/layout/SidebarHamburger.tsx
+++ b/web/src/components/layout/SidebarHamburger.tsx
@@ -1,0 +1,25 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { FiMenu } from 'react-icons/fi';
+import { LuX } from 'react-icons/lu';
+import { Sidebar } from '../Sidebar';
+
+export const SidebarHamburger = () => {
+    return (
+        <Dialog.Root>
+            <Dialog.Trigger asChild>
+                <button className="md:hidden button aspect-square size-8 flex items-center justify-center">
+                    <FiMenu />
+                </button>
+            </Dialog.Trigger>
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40 data-[state=open]:animate-overlayShow" />
+                <Dialog.Content className="fixed inset-y-0 left-0 w-64 max-w-full bg-primary p-4 overflow-y-auto z-50 data-[state=open]:animate-contentShow">
+                    <Sidebar />
+                    <Dialog.Close className="absolute top-2 right-2 rounded-md p-1 hover:bg-secondary">
+                        <LuX className="size-5" />
+                    </Dialog.Close>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+};

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -16,7 +16,7 @@ function RootComponent() {
             <CommandMenu />
             <Navbar />
             <div className="flex flex-col gap-1 pb-16 max-w-screen">
-                <Sidebar />
+                <Sidebar className="hidden md:block" />
                 <Outlet />
             </div>
             <Toaster

--- a/web/src/routes/chat/$chatId.tsx
+++ b/web/src/routes/chat/$chatId.tsx
@@ -13,6 +13,7 @@ import { WorkshopAuthGuard } from '@/components/AuthGuard';
 import { UpDownScroller } from '@/components/UpDown';
 import { ChatMessage } from '@/components/workshop/ChatMessage';
 import { ConversationGraph } from '@/components/workshop/ConversationGraph';
+import { RightbarHamburger } from '@/components/layout/RightbarHamburger';
 import { queryClient } from '@/util/query';
 import {
     buildMessageTree,
@@ -127,13 +128,22 @@ const ChatWithSidebar = ({ chatId }: { chatId: string }) => {
         <>
             {/* Right Sidebar */}
             {chat?.messages && chat.messages.length > 0 && useTreeView && (
-                <div className="right-bar p-4">
-                    <ConversationGraph
-                        rootNodes={rootNodes}
-                        visibleMessages={visibleMessages}
-                        messageMap={messageMap}
-                    />
-                </div>
+                <>
+                    <RightbarHamburger>
+                        <ConversationGraph
+                            rootNodes={rootNodes}
+                            visibleMessages={visibleMessages}
+                            messageMap={messageMap}
+                        />
+                    </RightbarHamburger>
+                    <div className="right-bar p-4 hidden md:block">
+                        <ConversationGraph
+                            rootNodes={rootNodes}
+                            visibleMessages={visibleMessages}
+                            messageMap={messageMap}
+                        />
+                    </div>
+                </>
             )}
 
             {/* Main Chat */}
@@ -297,7 +307,7 @@ const Chat = ({
                                         editingMessage={editingMessage}
                                         onCancelEdit={cancelEdit}
                                     />
-                                    <div className="text-center text-sm py-1">
+                                    <div className="text-center text-sm py-1 hidden sm:block">
                                         This is a demo. Check important info.
                                     </div>
                                 </div>

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -4,17 +4,19 @@ import { LuBook, LuGithub, LuWandSparkles } from 'react-icons/lu';
 import { ProtocolAgendaUpcoming } from '@/components/agenda/Upcoming';
 import { TopicList } from '@/components/topic/TopicList';
 import { TopicsTrending } from '@/components/topic/TopicsTrending';
+import { RightbarHamburger } from '@/components/layout/RightbarHamburger';
 
 export const Route = createFileRoute('/')({
     component: RouteComponent,
 });
 
 function RouteComponent() {
+    const rightContent = <ProtocolAgendaUpcoming />;
+
     return (
         <>
-            <div className="right-bar p-4">
-                <ProtocolAgendaUpcoming />
-            </div>
+            <RightbarHamburger>{rightContent}</RightbarHamburger>
+            <div className="right-bar p-4 hidden md:block">{rightContent}</div>
             <div className="mx-auto w-full max-w-screen-lg pt-8 px-2 space-y-4">
                 <div className="space-y-4 mx-auto">
                     <div className="card flex-1 flex flex-col gap-1 h-fit col-span-full w-full">


### PR DESCRIPTION
## Summary
- add sidebar and rightbar hamburger components
- use sidebar hamburger in the navbar
- hide sidebars on small screens and show them in dialogs
- conceal chat disclaimer text on small devices

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844b8d47988832fbfa0dee39b71ba2b