### PR TITLE
Add blog module

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -326,6 +326,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom_syndication"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f68d23e2cb4fd958c705b91a6b4c80ceeaf27a9e11651272a8389d5ce1a4a3"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "diligent-date-parser",
+ "never",
+ "quick-xml 0.37.5",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +647,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -748,6 +777,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +902,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
@@ -879,6 +942,15 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "diligent-date-parser"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ede7d79366f419921e2e2f67889c12125726692a313bffb474bd5f37a581e9"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -915,6 +987,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1012,12 @@ name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -994,6 +1087,7 @@ dependencies = [
  "figment",
  "futures",
  "governor",
+ "html2md",
  "icalendar",
  "jsonwebtoken",
  "meilisearch-sdk",
@@ -1011,8 +1105,10 @@ dependencies = [
  "regex",
  "reqwest",
  "rrule",
+ "rss",
  "rustls",
  "schemars",
+ "scraper",
  "serde",
  "serde_json",
  "sqlx",
@@ -1131,6 +1227,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
 
 [[package]]
 name = "futures"
@@ -1267,6 +1373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1403,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1488,6 +1612,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "html2md"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cff9891f2e0d9048927fbdfc28b11bf378f6a93c7ba70b23d0fbee9af6071b4"
+dependencies = [
+ "html5ever 0.27.0",
+ "jni",
+ "lazy_static",
+ "markup5ever_rcdom",
+ "percent-encoding",
+ "regex",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token",
 ]
 
 [[package]]
@@ -1874,6 +2038,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2212,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+dependencies = [
+ "html5ever 0.27.0",
+ "markup5ever 0.12.1",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2420,18 @@ dependencies = [
  "tokio",
  "version_check",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2573,6 +2826,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -2594,6 +2848,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2700,7 +2967,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
- "quick-xml",
+ "quick-xml 0.36.2",
  "regex",
  "rfc7239",
  "rustls-pemfile",
@@ -2777,7 +3044,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "derive_more",
+ "derive_more 2.0.1",
  "email_address",
  "futures-util",
  "indexmap 2.9.0",
@@ -2786,7 +3053,7 @@ dependencies = [
  "num-traits",
  "poem",
  "poem-openapi-derive",
- "quick-xml",
+ "quick-xml 0.36.2",
  "regex",
  "serde",
  "serde_json",
@@ -2877,6 +3144,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2986,6 +3259,16 @@ checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -3322,6 +3605,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rss"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2107738f003660f0a91f56fd3e3bd3ab5d918b2ddaf1e1ec2136fb1c46f71bf"
+dependencies = [
+ "atom_syndication",
+ "derive_builder",
+ "never",
+ "quick-xml 0.37.5",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,6 +3810,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3536,6 +3855,25 @@ checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cssparser",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3649,6 +3987,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3998,6 +4345,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4501,17 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4575,6 +4958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,6 +4997,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4656,6 +5051,16 @@ name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -4852,6 +5257,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -5216,6 +5630,17 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xml5ever"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+]
 
 [[package]]
 name = "yansi"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -81,4 +81,7 @@ url = "2.5.4"
 meilisearch-sdk = "0.28.0"
 strip-tags = "0.1.0"
 discourse-webhooks = { version = "0.2", features = ["async"] }
+rss = "2.0.12"
+scraper = "0.23.1"
+html2md = "0.2.14"
 # openidconnect = { version = "4", default-features = false, features = ["rustls-tls"] }

--- a/app/migrations/0014_blog_module.sql
+++ b/app/migrations/0014_blog_module.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS blog_posts (
+    post_guid TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_description TEXT NOT NULL,
+    pubDate TIMESTAMP NOT NULL,
+    category TEXT NOT NULL,
+    image_url TEXT NOT NULL
+)

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -22,10 +22,23 @@ pub async fn main() -> Result<(), Error> {
     let discourse_state = state.clone();
     let discourse_handle = async_std::task::spawn(async move {
         sleep(Duration::from_secs(5)).await;
-        discourse_state.clone().discourse.start_all_indexers(discourse_state).await;
+        discourse_state
+            .clone()
+            .discourse
+            .start_all_indexers(discourse_state)
+            .await;
     });
+
+    let blog_state = state.clone();
+    let blog_handle = async_std::task::spawn(async move {
+        sleep(Duration::from_secs(10)).await;
+        Arc::new(blog_state.blog.clone())
+            .start_blog_service(blog_state)
+            .await;
+    });
+
     let server_handle = async_std::task::spawn(server::start_http(state));
 
-    join!(server_handle, discourse_handle);
+    join!(server_handle, discourse_handle, blog_handle);
     Ok(())
 }

--- a/app/src/modules/blog/mod.rs
+++ b/app/src/modules/blog/mod.rs
@@ -1,0 +1,174 @@
+use crate::state::AppState;
+use async_std::task::sleep;
+use chrono::DateTime;
+use reqwest::Client;
+use rss::Channel;
+use scraper::{Html, Selector};
+use std::{sync::Arc, time::Duration};
+
+#[derive(Debug, Clone, Default)]
+pub struct BlogService;
+
+impl BlogService {
+    pub fn new() -> Self {
+        Self {}
+    }
+    pub async fn start_blog_service(self: Arc<Self>, state: AppState) {
+        tracing::info!("Blog service started");
+
+        loop {
+            self.timer_tick(&state).await;
+
+            sleep(Duration::from_secs(15 * 60)).await;
+        }
+    }
+
+    async fn timer_tick(&self, state: &AppState) {
+        let client = Client::new();
+        let resp = match client
+            .get("https://blog.ethereum.org/en/feed.xml")
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("Failed to fetch feed: {:?}", e);
+                return;
+            }
+        };
+
+        let bytes = match resp.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!("Failed to read response bytes: {:?}", e);
+                return;
+            }
+        };
+
+        let channel = match Channel::read_from(&bytes[..]) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to parse RSS feed: {:?}", e);
+                return;
+            }
+        };
+
+        for item in channel.items() {
+            let guid = item.guid().map(|g| g.value()).unwrap_or_default();
+            let result = sqlx::query!(
+                "SELECT post_guid FROM blog_posts WHERE post_guid = $1",
+                guid
+            )
+            .fetch_optional(&state.database.pool)
+            .await;
+
+            match result {
+                Ok(Some(_)) => {
+                    tracing::debug!("Blog post already exists: {}", guid);
+                }
+                Ok(None) => {
+                    tracing::info!(
+                        "New blog post found: {}",
+                        item.title().unwrap_or("untitled")
+                    );
+
+                    let link = item.link().unwrap();
+                    let html_resp = match reqwest::get(link).await {
+                        Ok(r) => r,
+                        Err(e) => {
+                            tracing::error!("Failed to fetch blog post HTML: {:?}", e);
+                            return;
+                        }
+                    };
+
+                    let html_bytes = match html_resp.bytes().await {
+                        Ok(b) => b,
+                        Err(e) => {
+                            tracing::error!("Failed to read blog post HTML bytes: {:?}", e);
+                            return;
+                        }
+                    };
+
+                    let markdown_content = {
+                        let html =
+                            Html::parse_document(std::str::from_utf8(&html_bytes).unwrap_or(""));
+                        let article_selector = Selector::parse("article").unwrap();
+                        let article_html =
+                            if let Some(article) = html.select(&article_selector).next() {
+                                article.html()
+                            } else {
+                                tracing::warn!("No <article> tag found in blog post: {}", link);
+                                continue;
+                            };
+
+                        let mut clean_html = article_html;
+
+                        clean_html = regex::Regex::new(r"<style[^>]*>[\s\S]*?</style>")
+                            .unwrap()
+                            .replace_all(&clean_html, "")
+                            .to_string();
+
+                        clean_html = regex::Regex::new(r"<script[^>]*>[\s\S]*?</script>")
+                            .unwrap()
+                            .replace_all(&clean_html, "")
+                            .to_string();
+
+                        clean_html = regex::Regex::new(r#"\s+class="[^"]*""#)
+                            .unwrap()
+                            .replace_all(&clean_html, "")
+                            .to_string();
+
+                        clean_html = regex::Regex::new(r#"\s+style="[^"]*""#)
+                            .unwrap()
+                            .replace_all(&clean_html, "")
+                            .to_string();
+
+                        html2md::parse_html(&clean_html)
+                    };
+
+                    let image_url = {
+                        let image_selector =
+                            Selector::parse("main > div > div > span > img").unwrap();
+                        let html_str = std::str::from_utf8(&html_bytes).unwrap_or("");
+                        let image_element = Html::parse_document(html_str)
+                            .select(&image_selector)
+                            .next()
+                            .and_then(|img| img.value().attr("src"))
+                            .map(|src| src.to_string());
+                        image_element.unwrap_or_default()
+                    };
+
+                    tracing::info!(
+                        "Extracted {} characters of markdown content",
+                        markdown_content.len()
+                    );
+
+                    if let Err(e) = sqlx::query!(
+                        "INSERT INTO blog_posts (post_guid, title, content, content_description, pubDate, category, image_url) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                        guid,
+                        item.title().unwrap_or("untitled"),
+                        markdown_content,
+                        item.description().unwrap_or(""),
+                        {
+                            let pub_date_str = item.pub_date().unwrap_or("1970-01-01T00:00:00Z");
+                            DateTime::parse_from_rfc2822(pub_date_str)
+                                .or_else(|_| DateTime::parse_from_rfc3339(pub_date_str))
+                                .map(|dt| dt.naive_utc())
+                                .unwrap_or_else(|_| DateTime::from_timestamp(0, 0).unwrap().naive_utc())
+                        },
+                        item.categories().get(0).map(|c| c.name()).unwrap_or("Uncategorized"),
+                        image_url
+                    )
+                    .execute(&state.database.pool)
+                    .await
+                    {
+                        tracing::error!("Failed to insert blog post: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Database error: {:?}", e);
+                }
+            }
+        }
+    }
+}

--- a/app/src/modules/mod.rs
+++ b/app/src/modules/mod.rs
@@ -1,3 +1,4 @@
+pub mod blog;
 pub mod discourse;
 pub mod ical;
 pub mod meili;

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -1,6 +1,7 @@
 use crate::{
     database::Database,
     modules::{
+        blog::BlogService,
         discourse::{self, DiscourseService},
         ical::{self, ICalConfig},
         meili,
@@ -25,6 +26,7 @@ pub struct AppStateInner {
     pub database: Database,
     pub ical: Option<ICalConfig>,
     pub discourse: DiscourseService,
+    pub blog: BlogService,
     pub pm: PMModule,
     pub sso: Option<SSOService>,
     pub workshop: WorkshopService,
@@ -54,6 +56,8 @@ impl AppStateInner {
         let discourse_configs = discourse::create_discourse_configs();
         let discourse = DiscourseService::new(discourse_configs);
 
+        let blog = BlogService::new();
+
         let pm = PMModule::default();
 
         let meili = meili::init_meili().await;
@@ -77,6 +81,7 @@ impl AppStateInner {
             ical,
             cache,
             discourse,
+            blog,
             pm,
             workshop,
             sso,


### PR DESCRIPTION
Introduces a blog module that fetches RSS feed from a specified blog, parses HTML content, converts it to markdown, and stores it in the database.

This automates the process of collecting and archiving blog content for later usage.